### PR TITLE
Refactor backend routes into modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A comprehensive AI-powered freelancer productivity platform that provides intell
 ## Features
 
 ### 🤖 AI Assistant
-- **Multi-LLM Support**: Choose from GPT-4o, GPT-4 Turbo, GPT-3.5 Turbo, Claude 3 Sonnet, and Claude 3 Opus
+- **Multi-LLM Support**: Choose from GPT-4o, GPT-4 Turbo, and GPT-3.5 Turbo
 - **Full App Access**: AI can manage tasks, projects, clients, bookings, events, and settings
 - **Smart Entity Creation**: Two-phase approach - mandatory fields first, then optional enhancements
 - **Immediate Analytics**: Comprehensive numerical summaries with detailed breakdowns

--- a/server/ai/CommandParser.ts
+++ b/server/ai/CommandParser.ts
@@ -1,0 +1,6 @@
+import { CommandRoutingResult } from "../openai";
+import { routeInputToApis } from "../openai";
+
+export async function parseCommand(message: string, context?: string, model: string = 'gpt-4o'): Promise<CommandRoutingResult> {
+  return routeInputToApis(message, context, model);
+}

--- a/server/ai/CommandRouter.ts
+++ b/server/ai/CommandRouter.ts
@@ -1,0 +1,13 @@
+import { parseCommand } from './CommandParser';
+import { executeUserCommand } from '../commandExecutorService';
+import { getContext, updateContext } from './ContextStore';
+
+export async function handleCommand(userId: string, message: string, model: string = 'gpt-4o') {
+  const context = getContext(userId);
+  const routing = await parseCommand(message, context, model);
+  const result = await executeUserCommand(userId, message, routing);
+  if (routing.conversation_context) {
+    updateContext(userId, routing.conversation_context);
+  }
+  return result;
+}

--- a/server/ai/ContextStore.ts
+++ b/server/ai/ContextStore.ts
@@ -1,0 +1,9 @@
+const contextMap = new Map<string, string>();
+
+export function getContext(userId: string) {
+  return contextMap.get(userId);
+}
+
+export function updateContext(userId: string, context: string) {
+  contextMap.set(userId, context);
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,5 +1,5 @@
 import express, { type Request, Response, NextFunction } from "express";
-import { registerRoutes } from "./routes";
+import { registerRoutes } from "./routes/index";
 import { setupVite, serveStatic, log } from "./vite";
 
 const app = express();

--- a/server/routes/ai.ts
+++ b/server/routes/ai.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { chatWithLLM, processCommand } from "../ai";
+import { handleCommand } from "../ai/CommandRouter";
 
 const router = Router();
 
@@ -105,6 +106,21 @@ router.post("/task-summary", async (req, res) => {
       success: false,
       result: "An error occurred while generating the task summary."
     });
+  }
+});
+
+// Unified command endpoint using new command router
+router.post("/command", async (req, res) => {
+  const { message, userId = "user-1", model } = req.body;
+  if (!message || typeof message !== "string") {
+    return res.status(400).json({ message: "Invalid request" });
+  }
+  try {
+    const result = await handleCommand(userId, message, model);
+    res.json(result);
+  } catch (err) {
+    console.error("Error handling command:", err);
+    res.status(500).json({ message: "Failed to process command" });
   }
 });
 

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -1,0 +1,34 @@
+import { Router } from "express";
+import { storage } from "../storage";
+import { insertUserSchema } from "@shared/schema";
+import { z } from "zod";
+
+const router = Router();
+
+router.post("/register", async (req, res) => {
+  try {
+    const signupSchema = insertUserSchema.extend({
+      fullName: z.string().min(1, "Full name is required"),
+    });
+    const { fullName, ...userData } = signupSchema.parse({
+      ...req.body,
+      username: req.body.username || req.body.email,
+    });
+    const nameParts = fullName.trim().split(/\s+/);
+    const name = nameParts.length > 0 ? nameParts.join(" ") : fullName;
+    const user = await storage.createUser({
+      ...userData,
+      name,
+    });
+    const { password, ...userWithoutPassword } = user;
+    res.status(201).json({ message: "User registered successfully", user: userWithoutPassword });
+  } catch (error) {
+    console.error("Error registering user:", error);
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({ message: "Validation failed", errors: error.errors });
+    }
+    res.status(500).json({ message: "Failed to register user" });
+  }
+});
+
+export default router;

--- a/server/routes/calendar.ts
+++ b/server/routes/calendar.ts
@@ -1,0 +1,59 @@
+import { Router } from "express";
+import { db } from "../db";
+import { tasks, bookings, events } from "@shared/schema";
+
+const router = Router();
+
+router.get("/", async (_req, res) => {
+  try {
+    const [taskList, bookingList, eventList] = await Promise.all([
+      db.select().from(tasks),
+      db.select().from(bookings),
+      db.select().from(events),
+    ]);
+
+    const items: { type: string; id: number; title: string; time: Date | null; linkedEntities: Record<string, number | null> }[] = [];
+
+    for (const t of taskList) {
+      items.push({
+        type: "task",
+        id: t.id,
+        title: t.title,
+        time: t.deadline ?? null,
+        linkedEntities: { projectId: t.projectId ?? null, clientId: t.clientId ?? null }
+      });
+    }
+    for (const e of eventList) {
+      items.push({
+        type: "event",
+        id: e.id,
+        title: e.title,
+        time: e.startTime,
+        linkedEntities: { projectId: e.projectId ?? null, clientId: e.clientId ?? null }
+      });
+    }
+    for (const b of bookingList) {
+      const dateTime = b.date && b.time ? new Date(`${b.date} ${b.time}`) : null;
+      items.push({
+        type: "booking",
+        id: b.id,
+        title: b.serviceName || "Booking",
+        time: dateTime,
+        linkedEntities: { projectId: b.projectId ?? null, clientId: b.clientId ?? null, taskId: b.taskId ?? null }
+      });
+    }
+
+    items.sort((a, b) => {
+      const aTime = a.time ? new Date(a.time).getTime() : 0;
+      const bTime = b.time ? new Date(b.time).getTime() : 0;
+      return aTime - bTime;
+    });
+
+    res.json(items);
+  } catch (err) {
+    console.error("Failed to fetch calendar items", err);
+    res.status(500).json({ message: "Failed to fetch calendar data" });
+  }
+});
+
+export default router;

--- a/server/routes/clients.ts
+++ b/server/routes/clients.ts
@@ -1,0 +1,91 @@
+import { Router } from "express";
+import { z } from "zod";
+import * as clients from "../services/clients.service";
+import { insertClientSchema } from "@shared/schema";
+
+const router = Router();
+
+router.get("/", async (_req, res) => {
+  const list = await clients.getClients();
+  res.json(list);
+});
+
+router.get("/:id", async (req, res) => {
+  const id = parseInt(req.params.id);
+  if (isNaN(id)) return res.status(400).json({ message: "Invalid client ID" });
+  const client = await clients.getClient(id);
+  if (!client) return res.status(404).json({ message: "Client not found" });
+  res.json(client);
+});
+
+router.post("/", async (req, res) => {
+  try {
+    const data = insertClientSchema.parse(req.body);
+    const client = await clients.createClient(data);
+    res.status(201).json(client);
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return res.status(400).json({ message: "Invalid client data", errors: err.errors });
+    }
+    res.status(500).json({ message: "Failed to create client" });
+  }
+});
+
+router.patch("/:id", async (req, res) => {
+  const id = parseInt(req.params.id);
+  if (isNaN(id)) return res.status(400).json({ message: "Invalid client ID" });
+  try {
+    const data = insertClientSchema.partial().parse(req.body);
+    const client = await clients.updateClient(id, data);
+    if (!client) return res.status(404).json({ message: "Client not found" });
+    res.json(client);
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return res.status(400).json({ message: "Invalid client data", errors: err.errors });
+    }
+    res.status(500).json({ message: "Failed to update client" });
+  }
+});
+
+router.delete("/:id", async (req, res) => {
+  const id = parseInt(req.params.id);
+  if (isNaN(id)) return res.status(400).json({ message: "Invalid client ID" });
+  const deleted = await clients.deleteClient(id);
+  if (!deleted) return res.status(404).json({ message: "Client not found" });
+  res.status(204).end();
+});
+
+router.post("/cleanup", async (_req, res) => {
+  try {
+    const unconnected = await clients.getUnconnectedClients();
+    const duplicates = await clients.getDuplicateClients();
+    res.json({ unconnected, duplicates });
+  } catch (err) {
+    res.status(500).json({ message: "Failed to clean up clients" });
+  }
+});
+
+router.get("/:id/check-dependencies", async (req, res) => {
+  const id = parseInt(req.params.id);
+  if (isNaN(id)) return res.status(400).json({ message: "Invalid client ID" });
+  const restrictions: any[] = [];
+  try {
+    const events = await clients.getEvents("user-1");
+    const clientEvents = events.filter(e => e.clientId === id);
+    if (clientEvents.length) restrictions.push({ type: "events", count: clientEvents.length });
+  } catch {}
+  try {
+    const projects = await clients.getProjectsByClient(id);
+    if (projects.length) restrictions.push({ type: "projects", count: projects.length });
+    for (const p of projects) {
+      const tasks = await clients.getTasksByProject(p.id);
+      if (tasks.length) {
+        restrictions.push({ type: "tasks", count: tasks.length, projectId: p.id });
+        break;
+      }
+    }
+  } catch {}
+  res.json({ canDelete: restrictions.length === 0, restrictions });
+});
+
+export default router;

--- a/server/routes/events.ts
+++ b/server/routes/events.ts
@@ -1,0 +1,84 @@
+import { Router } from "express";
+import { z } from "zod";
+import * as events from "../services/events.service";
+
+const router = Router();
+
+router.get("/", async (req, res) => {
+  const userId = (req.query.userId as string) || "user-1";
+  try {
+    const list = await events.getEvents(userId);
+    res.json(list);
+  } catch (err) {
+    res.status(500).json({ message: "Failed to fetch events" });
+  }
+});
+
+router.get("/:id", async (req, res) => {
+  const id = parseInt(req.params.id);
+  if (isNaN(id)) return res.status(400).json({ message: "Invalid event ID" });
+  try {
+    const ev = await events.getEvent(id);
+    if (!ev) return res.status(404).json({ message: "Event not found" });
+    res.json(ev);
+  } catch {
+    res.status(500).json({ message: "Failed to fetch event" });
+  }
+});
+
+router.post("/", async (req, res) => {
+  try {
+    const { userId, title, description, startTime, endTime, location, clientName, isConfirmed, eventType, color } = req.body;
+    if (!title) return res.status(400).json({ message: "Title is required" });
+    const data = {
+      userId: userId || "user-1",
+      title,
+      description: description || null,
+      startTime: new Date(startTime),
+      endTime: new Date(endTime),
+      location: location || null,
+      clientName: clientName || null,
+      isConfirmed: Boolean(isConfirmed),
+      eventType: eventType || "busy",
+      color: color || null
+    };
+    const ev = await events.createEvent(data as any);
+    res.status(201).json(ev);
+  } catch (err) {
+    res.status(500).json({ message: "Failed to create event" });
+  }
+});
+
+router.patch("/:id", async (req, res) => {
+  const id = parseInt(req.params.id);
+  if (isNaN(id)) return res.status(400).json({ message: "Invalid event ID" });
+  try {
+    const data: any = {};
+    const { userId, title, description, startTime, endTime, location, clientName, isConfirmed, eventType, color } = req.body;
+    if (title !== undefined) data.title = title;
+    if (description !== undefined) data.description = description || null;
+    if (location !== undefined) data.location = location || null;
+    if (clientName !== undefined) data.clientName = clientName || null;
+    if (isConfirmed !== undefined) data.isConfirmed = Boolean(isConfirmed);
+    if (eventType !== undefined) data.eventType = eventType || "busy";
+    if (color !== undefined) data.color = color || null;
+    if (userId !== undefined) data.userId = userId;
+    if (startTime !== undefined) data.startTime = new Date(startTime);
+    if (endTime !== undefined) data.endTime = new Date(endTime);
+    const ev = await events.updateEvent(id, data);
+    if (!ev) return res.status(404).json({ message: "Event not found" });
+    res.json(ev);
+  } catch (err) {
+    res.status(500).json({ message: "Failed to update event" });
+  }
+});
+
+router.delete("/:id", async (req, res) => {
+  const id = parseInt(req.params.id);
+  if (isNaN(id)) return res.status(400).json({ message: "Invalid event ID" });
+  const success = await events.deleteEvent(id);
+  if (!success) return res.status(404).json({ message: "Event not found" });
+  res.status(204).send();
+});
+
+export default router;

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -1,0 +1,35 @@
+import { Express } from "express";
+import { createServer, Server } from "http";
+import authRoutes from "./auth";
+import clientsRoutes from "./clients";
+import projectsRoutes from "./projects";
+import tasksRoutes from "./tasks";
+import bookingsRoutes from "./bookings";
+import eventsRoutes from "./events";
+import aiRoutes from "./ai";
+import calendarRoutes from "./calendar";
+import linkRoutes from "./links";
+import { registerPublicProfileRoutes } from "./publicProfile";
+import { registerRoutes as legacyRoutes } from "./legacy";
+
+export async function registerRoutes(app: Express): Promise<Server> {
+  app.use("/api/auth", authRoutes);
+  app.use("/api/clients", clientsRoutes);
+  app.use("/api/projects", projectsRoutes);
+  app.use("/api/tasks", tasksRoutes);
+  app.use("/api/bookings", bookingsRoutes);
+  app.use("/api/events", eventsRoutes);
+  app.use("/api/ai", aiRoutes);
+  app.use("/api/calendar", calendarRoutes);
+  app.use("/api/links", linkRoutes);
+
+  // Mount legacy routes for remaining endpoints
+  await legacyRoutes(app);
+
+  registerPublicProfileRoutes(app);
+
+  const httpServer = createServer(app);
+  return httpServer;
+}
+
+export default registerRoutes;

--- a/server/routes/legacy.ts
+++ b/server/routes/legacy.ts
@@ -36,6 +36,8 @@ import { z } from "zod";
 import { registerPublicProfileRoutes } from "./routes/publicProfile";
 import aiRoutes from "./routes/ai";
 import bookingsRoutes from "./routes/bookings";
+import calendarRoutes from "./routes/calendar";
+import linkRoutes from "./routes/links";
 
 // Helper functions for navigation tracking
 function getDisplayNameForPath(path: string): string {
@@ -2990,6 +2992,8 @@ Remember: The most helpful thing you can do is direct users to the specialized t
   // Register API routes
   app.use("/api/ai", aiRoutes);
   app.use("/api/bookings", bookingsRoutes);
+  app.use("/api/calendar", calendarRoutes);
+  app.use("/api/links", linkRoutes);
   
   const httpServer = createServer(app);
   return httpServer;

--- a/server/routes/links.ts
+++ b/server/routes/links.ts
@@ -1,0 +1,41 @@
+import { Router } from "express";
+import { db } from "../db";
+import { entityLinks, insertEntityLinkSchema } from "@shared/schema";
+import { ZodError } from "zod";
+import { eq } from "drizzle-orm";
+
+const router = Router();
+
+router.post("/", async (req, res) => {
+  try {
+    const data = insertEntityLinkSchema.parse(req.body);
+    const [link] = await db.insert(entityLinks).values(data).returning();
+    res.json(link);
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return res.status(400).json({ message: err.errors });
+    }
+    console.error("Failed to create link", err);
+    res.status(500).json({ message: "Failed to create link" });
+  }
+});
+
+router.get("/:id", async (req, res) => {
+  const id = parseInt(req.params.id);
+  const [link] = await db.select().from(entityLinks).where(eq(entityLinks.id, id));
+  if (!link) return res.status(404).json({ message: "Link not found" });
+  res.json(link);
+});
+
+router.delete("/:id", async (req, res) => {
+  const id = parseInt(req.params.id);
+  try {
+    await db.delete(entityLinks).where(eq(entityLinks.id, id));
+    res.json({ success: true });
+  } catch (err) {
+    console.error("Failed to delete link", err);
+    res.status(500).json({ message: "Failed to delete link" });
+  }
+});
+
+export default router;

--- a/server/routes/projects.ts
+++ b/server/routes/projects.ts
@@ -1,0 +1,78 @@
+import { Router } from "express";
+import { z } from "zod";
+import * as projects from "../services/projects.service";
+
+const router = Router();
+
+router.get("/", async (req, res) => {
+  const clientId = req.query.clientId ? parseInt(req.query.clientId as string) : undefined;
+  if (clientId) {
+    if (isNaN(clientId)) return res.status(400).json({ message: "Invalid client ID" });
+    return res.json(await projects.getProjectsByClient(clientId));
+  }
+  res.json(await projects.getProjects());
+});
+
+router.get("/:id", async (req, res) => {
+  const id = parseInt(req.params.id);
+  if (isNaN(id)) return res.status(400).json({ message: "Invalid project ID" });
+  const project = await projects.getProject(id);
+  if (!project) return res.status(404).json({ message: "Project not found" });
+  res.json(project);
+});
+
+router.post("/", async (req, res) => {
+  try {
+    const { name, description, clientId, status, startDate, endDate, budget } = req.body;
+    if (!name || typeof name !== 'string' || name.trim().length < 2) {
+      return res.status(400).json({ message: "Invalid project data", errors: [{ path: ['name'], message: 'Name must be at least 2 characters' }] });
+    }
+    const data = {
+      name: name.trim(),
+      description: description || null,
+      clientId: clientId || null,
+      status: status || "not_started",
+      startDate: startDate ? new Date(startDate) : null,
+      endDate: endDate ? new Date(endDate) : null,
+      budget: budget ? Number(budget) : null
+    };
+    const project = await projects.createProject(data as any);
+    res.status(201).json(project);
+  } catch (err) {
+    res.status(500).json({ message: "Failed to create project" });
+  }
+});
+
+router.patch("/:id", async (req, res) => {
+  const id = parseInt(req.params.id);
+  if (isNaN(id)) return res.status(400).json({ message: "Invalid project ID" });
+  try {
+    const { name, description, clientId, status, startDate, endDate, budget } = req.body;
+    const data: any = {};
+    if (name !== undefined) data.name = name;
+    if (description !== undefined) data.description = description || null;
+    if (clientId !== undefined) data.clientId = clientId || null;
+    if (status !== undefined) data.status = status;
+    if (startDate !== undefined) data.startDate = startDate ? new Date(startDate) : null;
+    if (endDate !== undefined) data.endDate = endDate ? new Date(endDate) : null;
+    if (budget !== undefined) data.budget = budget ? Number(budget) : null;
+    const project = await projects.updateProject(id, data);
+    if (!project) return res.status(404).json({ message: "Project not found" });
+    res.json(project);
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return res.status(400).json({ message: "Invalid project data", errors: err.errors });
+    }
+    res.status(500).json({ message: "Failed to update project" });
+  }
+});
+
+router.delete("/:id", async (req, res) => {
+  const id = parseInt(req.params.id);
+  if (isNaN(id)) return res.status(400).json({ message: "Invalid project ID" });
+  const deleted = await projects.deleteProject(id);
+  if (!deleted) return res.status(404).json({ message: "Project not found" });
+  res.status(204).end();
+});
+
+export default router;

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -1,0 +1,81 @@
+import { Router } from "express";
+import { z } from "zod";
+import * as tasks from "../services/tasks.service";
+import { insertTaskSchema, TaskPriority, TaskStatus } from "@shared/schema";
+
+const router = Router();
+
+router.get("/", async (req, res) => {
+  const projectId = req.query.projectId ? parseInt(req.query.projectId as string) : undefined;
+  if (projectId) {
+    if (isNaN(projectId)) return res.status(400).json({ message: "Invalid project ID" });
+    return res.json(await tasks.getTasksByProject(projectId));
+  }
+  res.json(await tasks.getTasks());
+});
+
+router.get("/:id", async (req, res) => {
+  const id = parseInt(req.params.id);
+  if (isNaN(id)) return res.status(400).json({ message: "Invalid task ID" });
+  const task = await tasks.getTask(id);
+  if (!task) return res.status(404).json({ message: "Task not found" });
+  res.json(task);
+});
+
+router.post("/", async (req, res) => {
+  try {
+    const data = insertTaskSchema.parse(req.body);
+    const task = await tasks.createTask(data);
+    res.status(201).json(task);
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return res.status(400).json({ message: "Invalid task data", errors: err.errors });
+    }
+    res.status(500).json({ message: "Failed to create task" });
+  }
+});
+
+router.patch("/:id", async (req, res) => {
+  const id = parseInt(req.params.id);
+  if (isNaN(id)) return res.status(400).json({ message: "Invalid task ID" });
+  try {
+    const updateSchema = z.object({
+      title: z.string().optional(),
+      description: z.string().nullable().optional(),
+      projectId: z.number().optional(),
+      status: z.enum([
+        TaskStatus.TO_DO,
+        TaskStatus.IN_PROGRESS,
+        TaskStatus.REVIEW,
+        TaskStatus.COMPLETED,
+      ]).optional(),
+      priority: z.enum([
+        TaskPriority.LOW,
+        TaskPriority.MEDIUM,
+        TaskPriority.HIGH,
+        TaskPriority.URGENT,
+      ]).optional(),
+      deadline: z.string().nullable().optional().transform(val => val ? new Date(val) : null),
+      completed: z.boolean().optional()
+    });
+    const data = updateSchema.parse(req.body);
+    const task = await tasks.updateTask(id, data);
+    if (!task) return res.status(404).json({ message: "Task not found" });
+    res.json(task);
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return res.status(400).json({ message: "Invalid task data", errors: err.errors });
+    }
+    res.status(500).json({ message: "Failed to update task" });
+  }
+});
+
+router.delete("/:id", async (req, res) => {
+  const id = parseInt(req.params.id);
+  if (isNaN(id)) return res.status(400).json({ message: "Invalid task ID" });
+  const deleted = await tasks.deleteTask(id);
+  if (!deleted) return res.status(404).json({ message: "Task not found" });
+  res.status(204).end();
+});
+
+export default router;

--- a/server/services/bookings.service.ts
+++ b/server/services/bookings.service.ts
@@ -1,0 +1,9 @@
+import { storage } from "../storage";
+import { InsertBooking } from "@shared/schema";
+
+export const getBookings = () => storage.getBookings();
+export const getBookingsByClient = (clientId: number) => storage.getBookingsByClient(clientId);
+export const getBooking = (id: number) => storage.getBooking(id);
+export const createBooking = (data: InsertBooking) => storage.createBooking(data);
+export const updateBooking = (id: number, data: Partial<InsertBooking>) => storage.updateBooking(id, data);
+export const deleteBooking = (id: number) => storage.deleteBooking(id);

--- a/server/services/clients.service.ts
+++ b/server/services/clients.service.ts
@@ -1,0 +1,13 @@
+import { storage } from "../storage";
+import { InsertClient } from "@shared/schema";
+
+export const getClients = () => storage.getClients();
+export const getClient = (id: number) => storage.getClient(id);
+export const createClient = (data: InsertClient) => storage.createClient(data);
+export const updateClient = (id: number, data: Partial<InsertClient>) => storage.updateClient(id, data);
+export const deleteClient = (id: number) => storage.deleteClient(id);
+export const getUnconnectedClients = () => storage.getUnconnectedClients();
+export const getDuplicateClients = () => storage.getDuplicateClients();
+export const getProjectsByClient = (id: number) => storage.getProjectsByClient(id);
+export const getEvents = (userId: string) => storage.getEvents(userId);
+export const getTasksByProject = (projectId: number) => storage.getTasksByProject(projectId);

--- a/server/services/events.service.ts
+++ b/server/services/events.service.ts
@@ -1,0 +1,15 @@
+import { storage } from "../storage";
+import { InsertEvent, InsertEventTemplate } from "@shared/schema";
+
+export const getEvents = (userId: string) => storage.getEvents(userId);
+export const getEvent = (id: number) => storage.getEvent(id);
+export const createEvent = (data: InsertEvent) => storage.createEvent(data);
+export const updateEvent = (id: number, data: Partial<InsertEvent>) => storage.updateEvent(id, data);
+export const deleteEvent = (id: number) => storage.deleteEvent(id);
+
+export const getEventTemplates = (userId: string) => storage.getEventTemplates(userId);
+export const getPublicEventTemplates = (userId: string) => storage.getPublicEventTemplates(userId);
+export const getEventTemplate = (id: number) => storage.getEventTemplate(id);
+export const createEventTemplate = (data: InsertEventTemplate) => storage.createEventTemplate(data);
+export const updateEventTemplate = (id: number, data: Partial<InsertEventTemplate>) => storage.updateEventTemplate(id, data);
+export const deleteEventTemplate = (id: number) => storage.deleteEventTemplate(id);

--- a/server/services/projects.service.ts
+++ b/server/services/projects.service.ts
@@ -1,0 +1,9 @@
+import { storage } from "../storage";
+import { InsertProject } from "@shared/schema";
+
+export const getProjects = () => storage.getProjects();
+export const getProjectsByClient = (clientId: number) => storage.getProjectsByClient(clientId);
+export const getProject = (id: number) => storage.getProject(id);
+export const createProject = (data: InsertProject) => storage.createProject(data);
+export const updateProject = (id: number, data: Partial<InsertProject>) => storage.updateProject(id, data);
+export const deleteProject = (id: number) => storage.deleteProject(id);

--- a/server/services/tasks.service.ts
+++ b/server/services/tasks.service.ts
@@ -1,0 +1,9 @@
+import { storage } from "../storage";
+import { InsertTask } from "@shared/schema";
+
+export const getTasks = () => storage.getTasks();
+export const getTasksByProject = (projectId: number) => storage.getTasksByProject(projectId);
+export const getTask = (id: number) => storage.getTask(id);
+export const createTask = (data: InsertTask) => storage.createTask(data);
+export const updateTask = (id: number, data: Partial<InsertTask>) => storage.updateTask(id, data);
+export const deleteTask = (id: number) => storage.deleteTask(id);

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -337,6 +337,26 @@ export type InsertInvoiceItem = z.infer<typeof insertInvoiceItemSchema>;
 export type Booking = typeof bookings.$inferSelect;
 export type InsertBooking = z.infer<typeof insertBookingSchema>;
 
+// Generic links between any two entities
+export const entityLinks = pgTable("entity_links", {
+  id: serial("id").primaryKey(),
+  fromType: text("from_type").notNull(),
+  fromId: integer("from_id").notNull(),
+  toType: text("to_type").notNull(),
+  toId: integer("to_id").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
+export const insertEntityLinkSchema = createInsertSchema(entityLinks).pick({
+  fromType: true,
+  fromId: true,
+  toType: true,
+  toId: true,
+});
+
+export type EntityLink = typeof entityLinks.$inferSelect;
+export type InsertEntityLink = z.infer<typeof insertEntityLinkSchema>;
+
 // Sign-up related schemas
 export const locationTypeEnum = pgEnum("location_type", [
   "has_shop",


### PR DESCRIPTION
## Summary
- break up the huge routes file
- create domain service layer
- centralize AI command flow with CommandRouter
- normalize data returned from calendar endpoint
- mount all routers from new `routes/index`

## Testing
- `npm run check` *(fails: filename casing issue)*

------
https://chatgpt.com/codex/tasks/task_e_68408ec4e714832f8c5d06ee378db729